### PR TITLE
expose WebSocket makeBuffer() method to be publically available

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,8 +876,11 @@ handler->setCacheControl("max-age=30");
 ```
 
 ### Specifying Date-Modified header
-It is possible to specify Date-Modified header to enable the server to return Not-Modified (304) response for requests
-with "If-Modified-Since" header with the same value, instead of responding with the actual file content.
+Sever sets "Last-Modified" header automatically if FS driver supports file modification timestamps (LittleFS does).
+Server returns "Not-Modified" (304) response for requests with "If-Modified-Since" header with _the same_ value as file's mod date, instead of responding with the actual file content. It does not perform date calculations checking if File's mod date is newer or later than in "If-Modified-Since" header.
+
+For FS not supporting file timestamps (like deprecated SPIFFS) it is possible to specify Date-Modified header manually.
+
 ```cpp
 // Update the date modified string every time files are updated
 server.serveStatic("/", SPIFFS, "/www/").setLastModified("Mon, 20 Jun 2016 14:00:00 GMT");

--- a/README.md
+++ b/README.md
@@ -823,8 +823,11 @@ handler->setCacheControl("max-age=30");
 ```
 
 ### Specifying Date-Modified header
-It is possible to specify Date-Modified header to enable the server to return Not-Modified (304) response for requests
-with "If-Modified-Since" header with the same value, instead of responding with the actual file content.
+Sever sets "Last-Modified" header automatically if FS driver supports file modification timestamps (LittleFS does).
+Server returns "Not-Modified" (304) response for requests with "If-Modified-Since" header with _the same_ value as file's mod date, instead of responding with the actual file content. It does not perform date calculations checking if File's mod date is newer or later than in "If-Modified-Since" header.
+
+For FS not supporting file timestamps (like deprecated SPIFFS) it is possible to specify Date-Modified header manually.
+
 ```cpp
 // Update the date modified string every time files are updated
 server.serveStatic("/", SPIFFS, "/www/").setLastModified("Mon, 20 Jun 2016 14:00:00 GMT");

--- a/library.json
+++ b/library.json
@@ -18,16 +18,9 @@
   "platforms": ["espressif8266", "espressif32"],
   "dependencies": [
     {
-      "owner": "me-no-dev",
-      "name": "ESPAsyncTCP",
-      "version": "^1.2.2",
-      "platforms": "espressif8266"
-    },
-    {
-      "owner": "me-no-dev",      
-      "name": "AsyncTCP",
-      "version": "^1.1.1",
-      "platforms": "espressif32"
+     "owner": "yubox-node-org",
+     "name": "AsyncTCPSock",
+     "version": "https://github.com/yubox-node-org/AsyncTCPSock"
     },
     {
       "name": "Hash",

--- a/library.json
+++ b/library.json
@@ -18,13 +18,10 @@
   "platforms": ["espressif8266", "espressif32"],
   "dependencies": [
     {
-     "owner": "yubox-node-org",
-     "name": "AsyncTCPSock",
-     "version": "https://github.com/yubox-node-org/AsyncTCPSock"
-    },
-    {
-      "name": "Hash",
-      "platforms": "espressif8266"
+      "owner": "esphome",
+      "name": "AsyncTCP-esphome",
+      "version": "^2.1.1",
+      "platforms": "espressif32"
     }
   ]
 }

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -208,7 +208,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
       _last_modified.concat(" GMT");
       _last_modified.setCharAt(29, 0);    // null terminate
     }
-    String etag(request->_tempFile.size());
+    String etag(lw ? lw : request->_tempFile.size());   // set etag to lastmod timestamp if available, otherwise to size
     if (_last_modified.length() && _last_modified == request->header("If-Modified-Since")) {
       request->_tempFile.close();
       request->send(304); // Not modified

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -20,6 +20,7 @@
 */
 #include "ESPAsyncWebServer.h"
 #include "WebHandlerImpl.h"
+#include <ctime>
 
 AsyncStaticWebHandler::AsyncStaticWebHandler(const char* uri, FS& fs, const char* path, const char* cache_control)
   : _fs(fs), _uri(uri), _path(path), _default_file("index.htm"), _cache_control(cache_control), _last_modified(""), _callback(nullptr)
@@ -196,17 +197,9 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
   if (request->_tempFile == true) {
     time_t lw = request->_tempFile.getLastWrite();    // get last file mod time (if supported by FS)
     if (lw) {
-      _last_modified.clear();
-      _last_modified.reserve(30);         // need 'Fri, 27 Jan 2023 15:50:27 GMT'
-      char *t = ctime(&lw);               // ctime 'Thu Jan 26 17:42:48 2023'
-      _last_modified.concat(t, 3);        // day of week
-      _last_modified.concat((char)0x2c);  // comma
-      _last_modified.concat(t+7, 3);      // day
-      _last_modified.concat(t+3, 4);      // month
-      _last_modified.concat(t+19, 5);     // year
-      _last_modified.concat(t+10, 9);     // time
-      _last_modified.concat(" GMT");
-      _last_modified.setCharAt(29, 0);    // null terminate
+      char datetime[std::size("Fri, 27 Jan 2023 15:50:27 GMT")];
+      std::strftime(std::data(datetime), std::size(datetime), "%a, %d %b %Y %H:%M:%S GMT", std::gmtime(&lw));
+      _last_modified = datetime;
     }
     String etag(lw ? lw : request->_tempFile.size());   // set etag to lastmod timestamp if available, otherwise to size
     if (_last_modified.length() && _last_modified == request->header("If-Modified-Since")) {

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -199,15 +199,29 @@ uint8_t AsyncStaticWebHandler::_countBits(const uint8_t value) const
 void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
 {
   // Get the filename from request->_tempObject and free it
-  String filename = String((char*)request->_tempObject);
+  String filename((char*)request->_tempObject);
   free(request->_tempObject);
   request->_tempObject = NULL;
   if((_username.length() && _password.length()) && !request->authenticate(_username.c_str(), _password.c_str()))
       return request->requestAuthentication();
 
   if (request->_tempFile == true) {
-    String etag = String(request->_tempFile.size());
-    if (_last_modified.length() && _last_modified == request->header(F("If-Modified-Since"))) {
+    time_t lw = request->_tempFile.getLastWrite();    // get last file mod time (if supported by FS)
+    if (lw) {
+      _last_modified.clear();
+      _last_modified.reserve(30);         // need 'Fri, 27 Jan 2023 15:50:27 GMT'
+      char *t = ctime(&lw);               // ctime 'Thu Jan 26 17:42:48 2023'
+      _last_modified.concat(t, 3);        // day of week
+      _last_modified.concat((char)0x2c);  // comma
+      _last_modified.concat(t+7, 3);      // day
+      _last_modified.concat(t+3, 4);      // month
+      _last_modified.concat(t+19, 5);     // year
+      _last_modified.concat(t+10, 9);     // time
+      _last_modified.concat(" GMT");
+      _last_modified.setCharAt(29, 0);    // null terminate
+    }
+    String etag(request->_tempFile.size());
+    if (_last_modified.length() && _last_modified == request->header("If-Modified-Since")) {
       request->_tempFile.close();
       request->send(304); // Not modified
     } else if (_cache_control.length() && request->hasHeader(F("If-None-Match")) && request->header(F("If-None-Match")).equals(etag)) {

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -208,12 +208,8 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
 
   if (request->_tempFile == true) {
     time_t lw = request->_tempFile.getLastWrite();    // get last file mod time (if supported by FS)
-    if (lw) {
-      char datetime[std::size("Fri, 27 Jan 2023 15:50:27 GMT")];
-      std::strftime(std::data(datetime), std::size(datetime), "%a, %d %b %Y %H:%M:%S GMT", std::gmtime(&lw));
-      _last_modified = datetime;
-    }
-    String etag(request->_tempFile.size());
+    if (lw) setLastModified(std::gmtime(&lw));
+    String etag(lw ? lw : request->_tempFile.size());   // set etag to lastmod timestamp if available, otherwise to size
     if (_last_modified.length() && _last_modified == request->header("If-Modified-Since")) {
       request->_tempFile.close();
       request->send(304); // Not modified


### PR DESCRIPTION
Nice work done here refactoring AsyncWebServer, really like it!
Want to suggest exposing `AsyncWebSocketClient::makeBuffer()` method to be public. The origin AsyncWebServer has this feature and sometimes it really helps to avoid extra data copy or mem allocations.
I.e. I use it like this with ArduinoJson

```c++
void send(const JsonObject& data){
    size_t length = measureJson(data);
    AsyncWebSocketMessageBuffer buffer = ws->makeBuffer(length);
    if (!buffer) return;

    serializeJson(data, (char*)buffer->data() , length);
    ws->textAll(buffer);
};

```